### PR TITLE
[Mithril] Fix incorrect pricing in catalog fetcher

### DIFF
--- a/sky/catalog/data_fetchers/fetch_mithril.py
+++ b/sky/catalog/data_fetchers/fetch_mithril.py
@@ -68,9 +68,10 @@ def fetch_instance_types(api_key: str, api_url: str) -> List[Dict[str, Any]]:
             f'Failed to fetch instance types: {e}') from e
 
 
-def fetch_instance_pricing(api_key: str, api_url: str,
-                           instance_fid: str) -> float:
-    """Fetch minimum price for an instance type from Mithril Pricing API.
+def fetch_instance_pricing(
+        api_key: str, api_url: str,
+        instance_fid: str) -> Dict[str, float]:
+    """Fetch on-demand and spot prices for an instance type.
 
     Args:
         api_key: API key for authentication
@@ -78,7 +79,8 @@ def fetch_instance_pricing(api_key: str, api_url: str,
         instance_fid: Instance type FID (e.g., 'it_XqgKWbhZ5gznAYsG')
 
     Returns:
-        Price in dollars (converted from minimum_price_cents).
+        Dict with 'price' (on-demand, from reserved_price_cents) and
+        'spot_price' (from spot_price_cents), both in dollars.
     """
     endpoint = f'{api_url}/v2/pricing/current'
 
@@ -91,7 +93,10 @@ def fetch_instance_pricing(api_key: str, api_url: str,
         )
         response.raise_for_status()
         data = response.json()
-        return data['minimum_price_cents'] / 100.0
+        return {
+            'price': data['reserved_price_cents'] / 100.0,
+            'spot_price': data['spot_price_cents'] / 100.0,
+        }
     except requests.exceptions.RequestException as e:
         raise mithril_utils.MithrilError(
             f'Failed to fetch pricing for {instance_fid}: {e}') from e
@@ -145,7 +150,7 @@ def create_catalog(output_path: str = 'mithril/vms.csv') -> None:
     logger.info('Found %d instance types.', len(instance_types))
 
     logger.info('Fetching pricing for each instance type...')
-    instance_pricing: Dict[str, float] = {}
+    instance_pricing: Dict[str, Dict[str, float]] = {}
     for inst in instance_types:
         instance_pricing[inst['fid']] = fetch_instance_pricing(
             api_key, api_url, inst['fid'])
@@ -187,7 +192,7 @@ def create_catalog(output_path: str = 'mithril/vms.csv') -> None:
             gpu_info = (make_gpu_info_json(gpu_name, gpu_count, gpu_memory_gb)
                         if gpu_count else '')
 
-            price = instance_pricing[inst['fid']]
+            pricing = instance_pricing[inst['fid']]
 
             for item in regions_with_prices:
                 writer.writerow([
@@ -196,8 +201,8 @@ def create_catalog(output_path: str = 'mithril/vms.csv') -> None:
                     gpu_count or '',
                     vcpus,
                     memory_gb,
-                    price,
-                    price,
+                    pricing['price'],
+                    item['spot_price'],
                     item['region'],
                     gpu_info,
                 ])


### PR DESCRIPTION
## Summary
- Fixed on-demand price using wrong API field (`minimum_price_cents` → `reserved_price_cents`), which was producing prices like $0.01/hr for a B200 GPU instead of $3.45/hr
- Fixed spot price column being populated with the on-demand price instead of actual spot prices from the availability API

**Price comparison (before → after):**
| Instance | Old Price | Correct Price | Old Spot | Correct Spot |
|---|---|---|---|---|
| neb-b200.sxm.1x | $0.01 | $3.45 | $0.01 | $0.05 |
| h100-80gb.sxm.8x | $8.00 | $28.66 | $8.00 | $8.00 |
| a100-80gb.sxm.8x | $0.08 | $13.99 | $0.08 | $0.50 |
| neb-b200.sxm.8x | $0.08 | $38.73 | $0.08 | $25.00 |

## Test plan
- [x] Verified API responses: `minimum_price_cents` is the bid floor (e.g. 1 cent), `reserved_price_cents` is the actual on-demand price, `spot_price_cents` is the spot price
- [x] Regenerated catalog CSV with the fix and confirmed correct prices for all 8 instance types
- [x] All 18 existing unit tests pass (`pytest tests/unit_tests/test_mithril.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)